### PR TITLE
Implement drag-and-drop equipping

### DIFF
--- a/game.css
+++ b/game.css
@@ -658,6 +658,10 @@ legend {
   background-color: rgba(136, 180, 127, 0.3);
 }
 
+#inventory-list.dragover {
+  background-color: rgba(136, 180, 127, 0.3);
+}
+
 
 .context-menu {
   position: absolute;


### PR DESCRIPTION
## Summary
- add highlight for inventory drop target
- allow dropping equipped items back to inventory
- use context-menu equip logic when dropping items on a slot
- attach drag events to equipped items
- cleanup old unused drag-and-drop code

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684adcfbf8608329a3d29048f1f1be80