### PR TITLE
Fix drag drop equip slot check

### DIFF
--- a/game.js
+++ b/game.js
@@ -390,7 +390,7 @@ document.querySelectorAll('.equipped-gear li').forEach(slotEl => {
     slotEl.classList.remove("dragover");
 
     const itemId = e.dataTransfer.getData("text/plain");
-    const item = player.inventory.find(i => i.id === itemId);
+    const item = items[itemId]; // look up full item data
     if (item && item.slot === slotType) {
       equipItemToSlot(itemId, slotType);
     }


### PR DESCRIPTION
## Summary
- use item data when checking drops on equipment slots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae327d7bc8329b9a8b862f343af59