### PR TITLE
Add prologue screen for new games

### DIFF
--- a/game.html
+++ b/game.html
@@ -276,6 +276,16 @@
       </div>
     </div>
 
+    <div id="prologue-modal" class="modal hidden" role="dialog" aria-labelledby="prologue-title">
+      <div class="modal-content">
+        <h2 id="prologue-title">Prologue: Ember in the Ironwood</h2>
+        <p>Long ago, a fragment of fallen star took root in the ancient Ironwood, its celestial spark guiding the forge fire at the heart of a fledgling settlement. Over centuries, that spark grew into Emberstone Forge—its green-tinted steel defended kingdoms and quelled uprisings, while Oakheart Village blossomed around its warm glow. Traders thronged the market square beneath striped awnings, and weary travelers found rest at the Root &amp; Hearth Inn, drawn by the promise of hot stew and softer beds.</p>
+        <p>But peace is never eternal. In recent moons, a strange hush has fallen across the forest. Caravans from the Vale of Whispers fail to arrive, and once-steady paths are littered with abandoned carts. Hunters speak of flickering lights between the trees, and smith’s apprentices whisper that the Emberstone’s glow has begun to weaken. Through shadowed branches, an unseen hand seems to twist the song of the wood into something darker.</p>
+        <p>Now you stand at Oakheart’s threshold, the forge’s embers painting your silhouette in molten gold. Marla the Merchant eyes you keenly from behind her stall, Borik the Smith’s hammer rings with urgent rhythm, and Tomas the Innkeeper offers a steady smile and a frothing mug. Here, at the edge of Ironwood, your journey begins: to rekindle the forge’s first fire, to unravel the forest’s secret stirrings, and to forge your own legend in the fires of Oakheart.</p>
+        <button id="prologue-close">Begin Adventure</button>
+      </div>
+    </div>
+
     <div id="tooltip" class="tooltip hidden">
       <h2 id="tooltip-name" class="tooltip-line">Item Name</h2>
       <p id="tooltip-damage" class="tooltip-pne"></p>

--- a/game.js
+++ b/game.js
@@ -58,9 +58,18 @@ function closeModal(modal) {
   }
 }
 
+function showPrologue() {
+  const modal = document.getElementById('prologue-modal');
+  const btn = document.getElementById('prologue-close');
+  if (!modal || !btn) return;
+  btn.addEventListener('click', () => closeModal(modal), { once: true });
+  openModal(modal);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
-  if (params.get('load') === '1') {
+  const isLoad = params.get('load') === '1';
+  if (isLoad) {
     loadSavedGame();
   }
 
@@ -70,6 +79,10 @@ document.addEventListener('DOMContentLoaded', () => {
   renderLocation();
   renderDestinationSidebar();
   renderInventory();
+
+  if (!isLoad) {
+    showPrologue();
+  }
 
   // Grab saved options in localstorage
   const savedScale = localStorage.getItem('uiScale') || '1';


### PR DESCRIPTION
## Summary
- add a modal in `game.html` that presents the game prologue
- create `showPrologue` helper and invoke it on fresh game start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0fb418688329827d751a1b54dcb3