### PR TITLE
Add prologue to Legends journal

### DIFF
--- a/game.js
+++ b/game.js
@@ -62,7 +62,10 @@ function showPrologue() {
   const modal = document.getElementById('prologue-modal');
   const btn = document.getElementById('prologue-close');
   if (!modal || !btn) return;
-  btn.addEventListener('click', () => closeModal(modal), { once: true });
+  btn.addEventListener('click', () => {
+    closeModal(modal);
+    unlockJournalEntry('legend-prologue');
+  }, { once: true });
   openModal(modal);
 }
 

--- a/journal.js
+++ b/journal.js
@@ -1,6 +1,7 @@
 import { enemies } from './enemy.js';
 import { locations } from './location.js';
 import { npcs } from './npcs.js';
+import { legends } from './legends.js';
 import { log } from './game.js'
 
 // journal.js
@@ -49,6 +50,19 @@ Object.values(npcs).forEach(npc => {
       tags: npc.journal.tags || []
     };
   }
+});
+
+// Load legend-based journal entries
+Object.values(legends).forEach(legend => {
+  journalEntries[legend.id] = {
+    id: legend.id,
+    title: legend.title,
+    text: legend.text,
+    unlocked: false,
+    category: 'legend',
+    locationHint: legend.locationHint,
+    tags: legend.tags || []
+  };
 });
 
 // This holds which entries are unlocked for the player

--- a/legends.js
+++ b/legends.js
@@ -1,0 +1,13 @@
+export const legends = {
+  'legend-prologue': {
+    id: 'legend-prologue',
+    title: 'Prologue: Ember in the Ironwood',
+    text: `Long ago, a fragment of fallen star took root in the ancient Ironwood, its celestial spark guiding the forge fire at the heart of a fledgling settlement. Over centuries, that spark grew into Emberstone Forge—its green-tinted steel defended kingdoms and quelled uprisings, while Oakheart Village blossomed around its warm glow. Traders thronged the market square beneath striped awnings, and weary travelers found rest at the Root & Hearth Inn, drawn by the promise of hot stew and softer beds.
+
+But peace is never eternal. In recent moons, a strange hush has fallen across the forest. Caravans from the Vale of Whispers fail to arrive, and once-steady paths are littered with abandoned carts. Hunters speak of flickering lights between the trees, and smith’s apprentices whisper that the Emberstone’s glow has begun to weaken. Through shadowed branches, an unseen hand seems to twist the song of the wood into something darker.
+
+Now you stand at Oakheart’s threshold, the forge’s embers painting your silhouette in molten gold. Marla the Merchant eyes you keenly from behind her stall, Borik the Smith’s hammer rings with urgent rhythm, and Tomas the Innkeeper offers a steady smile and a frothing mug. Here, at the edge of Ironwood, your journey begins: to rekindle the forge’s first fire, to unravel the forest’s secret stirrings, and to forge your own legend in the fires of Oakheart.`,
+    locationHint: 'Revisit the beginning at Oakheart Village.',
+    tags: ['legend', 'prologue']
+  }
+};


### PR DESCRIPTION
## Summary
- create `legends.js` with the prologue text
- load legends into the journal system
- unlock the prologue entry when the prologue modal closes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b126035dc83298a18c6e91063110c